### PR TITLE
Don't try to retrieve the MR author's email

### DIFF
--- a/patchlab/gitlab2email.py
+++ b/patchlab/gitlab2email.py
@@ -98,8 +98,6 @@ def _prepare_emails(gitlab, git_forge, project, merge_request):
         )
         return []
 
-    mr_author = gitlab.users.get(merge_request.author["id"])
-    mr_from = f"{mr_author.name} <{mr_author.email}>"
     commits = list(reversed(list(merge_request.commits())))
     num_commits = len(commits)
 
@@ -111,12 +109,14 @@ def _prepare_emails(gitlab, git_forge, project, merge_request):
             "Message-ID": email_utils.make_msgid(domain=DNS_NAME),
             "X-Patchlab-Merge-Request": f"{merge_request.web_url}",
         }
-        body = f"From: {mr_from}\n\n{merge_request.description}"
+        body = (
+            f"From: {merge_request.author['username']} on {git_forge.host}\n\n"
+            f"{merge_request.description}"
+        )
         cover_letter = EmailMessage(
             subject=f"[{branch.subject_prefix} PATCH 0/{num_commits}] {merge_request.title}",
             body=body,
             to=[git_forge.project.listemail],
-            cc=[mr_from],
             headers=headers,
             reply_to=[git_forge.project.listemail],
         )
@@ -167,7 +167,6 @@ def _prepare_emails(gitlab, git_forge, project, merge_request):
             subject=subject,
             body=f"From: {patch_author}\n\n{patch.get_payload()}",
             to=[git_forge.project.listemail],
-            cc=[mr_from],
             headers=headers,
             reply_to=[git_forge.project.listemail],
         )

--- a/patchlab/tests/__init__.py
+++ b/patchlab/tests/__init__.py
@@ -33,7 +33,6 @@ Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH] Bring balance to the equals signs
 From: Patchwork <patchwork@patchwork.example.com>
 To: kernel@lists.fedoraproject.org
-Cc: Administrator <admin@example.com>
 Reply-To: kernel@lists.fedoraproject.org
 Date: Mon, 04 Nov 2019 23:00:00 -0000
 Message-ID: <4@localhost.localdomain>
@@ -71,13 +70,12 @@ Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH 0/2] Update the README
 From: Patchwork <patchwork@patchwork.example.com>
 To: kernel@lists.fedoraproject.org
-Cc: Administrator <admin@example.com>
 Reply-To: kernel@lists.fedoraproject.org
 Date: Mon, 04 Nov 2019 23:00:00 -0000
 Message-ID: <1@localhost.localdomain>
 X-Patchlab-Merge-Request: https://gitlab/root/kernel/merge_requests/2
 
-From: Administrator <admin@example.com>
+From: root on gitlab.example.com
 
 Update the README to make me want to read it more.""",
     """Content-Type: text/plain; charset="utf-8"
@@ -86,7 +84,6 @@ Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH 1/2] Bring balance to the equals signs
 From: Patchwork <patchwork@patchwork.example.com>
 To: kernel@lists.fedoraproject.org
-Cc: Administrator <admin@example.com>
 Reply-To: kernel@lists.fedoraproject.org
 Date: Mon, 04 Nov 2019 23:00:00 -0000
 Message-ID: <2@localhost.localdomain>
@@ -123,7 +120,6 @@ Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH 2/2] Convert the README to restructured text
 From: Patchwork <patchwork@patchwork.example.com>
 To: kernel@lists.fedoraproject.org
-Cc: Administrator <admin@example.com>
 Reply-To: kernel@lists.fedoraproject.org
 Date: Mon, 04 Nov 2019 23:00:00 -0000
 Message-ID: <4@localhost.localdomain>
@@ -190,13 +186,12 @@ Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH 0/2] Update the README
 From: Patchwork <patchwork@patchwork.example.com>
 To: kernel@lists.fedoraproject.org
-Cc: Administrator <admin@example.com>
 Reply-To: kernel@lists.fedoraproject.org
 Date: Mon, 04 Nov 2019 23:00:00 -0000
 Message-ID: <4@localhost.localdomain>
 X-Patchlab-Merge-Request: https://gitlab/root/kernel/merge_requests/2
 
-From: Administrator <admin@example.com>
+From: root on gitlab.example.com
 
 Update the README to make me want to read it more.
 


### PR DESCRIPTION
Most people hide their email on their profiles and in retrospect if
they're opening a merge request they don't want the email anyway.
They'll see replies via bridged comments.

Signed-off-by: Jeremy Cline <jcline@redhat.com>