### PR TITLE
Retry tasks

### DIFF
--- a/patchlab/gitlab2email.py
+++ b/patchlab/gitlab2email.py
@@ -64,7 +64,6 @@ def email_merge_request(
             urllib.parse.urlsplit(gitlab.url).hostname,
         )
         return
-
     project = gitlab.projects.get(forge_id)
     merge_request = project.mergerequests.get(merge_id)
 

--- a/patchlab/gitlab2email.py
+++ b/patchlab/gitlab2email.py
@@ -71,7 +71,7 @@ def email_merge_request(
         for email in emails:
             try:
                 submission = _record_bridging(git_forge.project.listid, merge_id, email)
-            except ValueError as e:
+            except ValueError:
                 # This message is already in the database, skip sending it
                 continue
             email.connection = conn

--- a/patchlab/gitlab2email.py
+++ b/patchlab/gitlab2email.py
@@ -52,7 +52,7 @@ def email_merge_request(
     """Email a merge request to a mailing list."""
     try:
         git_forge = GitForge.objects.get(
-            host=urllib.parse.urlsplit(gitlab.url).hostname, forge_id=forge_id,
+            host=urllib.parse.urlsplit(gitlab.url).hostname, forge_id=forge_id
         )
     except GitForge.DoesNotExist:
         _log.error(

--- a/patchlab/gitlab2email.py
+++ b/patchlab/gitlab2email.py
@@ -4,7 +4,6 @@ This module deals with turning Gitlab objects (merge requests, comments) into
 emails.
 """
 from email import message_from_string, utils as email_utils
-from typing import List
 import logging
 import re
 import urllib

--- a/patchlab/migrations/0001_initial.py
+++ b/patchlab/migrations/0001_initial.py
@@ -9,9 +9,7 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-        ("patchwork", "0036_project_commit_url_format"),
-    ]
+    dependencies = [("patchwork", "0036_project_commit_url_format")]
 
     operations = [
         migrations.CreateModel(
@@ -124,7 +122,7 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.AlterUniqueTogether(
-            name="gitforge", unique_together={("host", "forge_id")},
+            name="gitforge", unique_together={("host", "forge_id")}
         ),
         migrations.AddIndex(
             model_name="branch",

--- a/patchlab/migrations/0002_drop_unique_commit.py
+++ b/patchlab/migrations/0002_drop_unique_commit.py
@@ -5,14 +5,12 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ("patchlab", "0001_initial"),
-    ]
+    dependencies = [("patchlab", "0001_initial")]
 
     operations = [
         migrations.AlterField(
             model_name="bridgedsubmission",
             name="commit",
             field=models.CharField(blank=True, max_length=128, null=True),
-        ),
+        )
     ]

--- a/patchlab/tasks.py
+++ b/patchlab/tasks.py
@@ -27,9 +27,7 @@ def open_merge_request(series_id: int) -> None:
         )
         return
     except ObjectDoesNotExist:
-        _log.error(
-            "No git forge associated with %s", str(series.project),
-        )
+        _log.error("No git forge associated with %s", str(series.project))
         return
 
     # This assumes Celery has been configured with an acceptable working directory
@@ -40,9 +38,7 @@ def open_merge_request(series_id: int) -> None:
     try:
         email_bridge.open_merge_request(gitlab, series, working_dir)
     except Exception as e:
-        _log.warning(
-            "Failed to open merge request, retry in 1 minute"
-        )
+        _log.warning("Failed to open merge request, retry in 1 minute")
         raise open_merge_request.retry(exc=e, throw=False, countdown=60)
 
 

--- a/patchlab/tasks.py
+++ b/patchlab/tasks.py
@@ -37,8 +37,13 @@ def open_merge_request(series_id: int) -> None:
     working_dir = os.path.join(os.getcwd(), str(current_process().name))
     if not os.path.exists(working_dir):
         os.mkdir(working_dir)
-
-    email_bridge.open_merge_request(gitlab, series, working_dir)
+    try:
+        email_bridge.open_merge_request(gitlab, series, working_dir)
+    except Exception as e:
+        _log.warning(
+                "Failed to open merge request, retry in 1 minute"
+        )
+        raise open_merge_request.retry(exc=e, throw=False, countdown=60)
 
 
 @shared_task
@@ -53,7 +58,13 @@ def merge_request_hook(gitlab_host: str, project_id: int, merge_id: int) -> None
         merge_request: The merge request web hook payload from GitLab
     """
     gitlab = gitlab_module.Gitlab.from_config(gitlab_host)
-    gitlab2email.email_merge_request(gitlab, project_id, merge_id)
+    try:
+        gitlab2email.email_merge_request(gitlab, project_id, merge_id)
+    except Exception as e:
+        _log.warning(
+                "Failed to email merge request from merge_request_hook, retrying in 1 minute"
+        )
+        raise merge_request_hook.retry(exc=e, throw=False, countdown=60)
 
 
 @shared_task

--- a/patchlab/tasks.py
+++ b/patchlab/tasks.py
@@ -41,7 +41,7 @@ def open_merge_request(series_id: int) -> None:
         email_bridge.open_merge_request(gitlab, series, working_dir)
     except Exception as e:
         _log.warning(
-                "Failed to open merge request, retry in 1 minute"
+            "Failed to open merge request, retry in 1 minute"
         )
         raise open_merge_request.retry(exc=e, throw=False, countdown=60)
 
@@ -62,7 +62,7 @@ def merge_request_hook(gitlab_host: str, project_id: int, merge_id: int) -> None
         gitlab2email.email_merge_request(gitlab, project_id, merge_id)
     except Exception as e:
         _log.warning(
-                "Failed to email merge request from merge_request_hook, retrying in 1 minute"
+            "Failed to email merge request from merge_request_hook, retrying in 1 minute"
         )
         raise merge_request_hook.retry(exc=e, throw=False, countdown=60)
 

--- a/patchlab/tests/test_bridge.py
+++ b/patchlab/tests/test_bridge.py
@@ -32,10 +32,10 @@ class OpenMergeRequestTests(BaseTestCase):
             scm_url="https://gitlab/root/patchlab_test.git",
         )
         cls.forge = models.GitForge.objects.create(
-            project=cls.project, host="gitlab", forge_id=1,
+            project=cls.project, host="gitlab", forge_id=1
         )
         cls.branch = models.Branch.objects.create(
-            git_forge=cls.forge, subject_prefix="TEST PATCH", name="master",
+            git_forge=cls.forge, subject_prefix="TEST PATCH", name="master"
         )
         parse_mail(message_from_string(SINGLE_COMMIT_MR), "patchlab.example.com")
         cls.gitlab = gitlab_module.Gitlab(
@@ -98,10 +98,10 @@ class NotifyAmFailureTests(BaseTestCase):
             web_url="https://gitlab.example.com/root/kernel",
         )
         self.forge = models.GitForge.objects.create(
-            project=self.project, host="gitlab.example.com", forge_id=1,
+            project=self.project, host="gitlab.example.com", forge_id=1
         )
         self.branch = models.Branch.objects.create(
-            git_forge=self.forge, subject_prefix="TEST PATCH", name="master",
+            git_forge=self.forge, subject_prefix="TEST PATCH", name="master"
         )
 
     def test_single_patch(self, mock_run):

--- a/patchlab/tests/test_gitlab2email.py
+++ b/patchlab/tests/test_gitlab2email.py
@@ -191,7 +191,8 @@ class RecordBridgingTests(BaseTestCase):
             self.gitlab, self.forge, self.project, merge_request
         )
 
-        gitlab2email._record_bridging(self.forge.project.listid, 1, emails)
+        for email in emails:
+            gitlab2email._record_bridging(self.forge.project.listid, 1, email)
 
         self.assertEqual(3, models.BridgedSubmission.objects.count())
         self.assertEqual(2, pw_models.Patch.objects.count())
@@ -204,7 +205,8 @@ class RecordBridgingTests(BaseTestCase):
             self.gitlab, self.forge, self.project, merge_request
         )
 
-        gitlab2email._record_bridging(self.forge.project.listid, 1, emails)
+        for email in emails:
+            gitlab2email._record_bridging(self.forge.project.listid, 1, email)
 
         self.assertEqual(1, models.BridgedSubmission.objects.count())
         self.assertEqual(1, pw_models.Patch.objects.count())
@@ -217,11 +219,13 @@ class RecordBridgingTests(BaseTestCase):
             self.gitlab, self.forge, self.project, merge_request
         )
 
-        gitlab2email._record_bridging(self.forge.project.listid, 1, emails)
-        self.assertRaises(
-            ValueError,
-            gitlab2email._record_bridging,
-            self.forge.project.listid,
-            1,
-            emails,
-        )
+        for email in emails:
+            gitlab2email._record_bridging(self.forge.project.listid, 1, email)
+
+            self.assertRaises(
+                ValueError,
+                gitlab2email._record_bridging,
+                self.forge.project.listid,
+                1,
+                email,
+            )

--- a/patchlab/tests/test_gitlab2email.py
+++ b/patchlab/tests/test_gitlab2email.py
@@ -48,10 +48,10 @@ class PrepareEmailsTests(BaseTestCase):
             listemail="kernel@lists.fedoraproject.org",
         )
         self.forge = models.GitForge.objects.create(
-            project=self.project, host="gitlab.example.com", forge_id=1,
+            project=self.project, host="gitlab.example.com", forge_id=1
         )
         self.branch = models.Branch.objects.create(
-            git_forge=self.forge, subject_prefix="TEST", name="internal",
+            git_forge=self.forge, subject_prefix="TEST", name="internal"
         )
 
     @mock.patch("patchlab.gitlab2email.email_utils.make_msgid")
@@ -175,10 +175,10 @@ class RecordBridgingTests(BaseTestCase):
             web_url="https://gitlab/root/kernel",
         )
         self.forge = models.GitForge.objects.create(
-            project=self.project, host="gitlab.example.com", forge_id=1,
+            project=self.project, host="gitlab.example.com", forge_id=1
         )
         self.branch = models.Branch.objects.create(
-            git_forge=self.forge, subject_prefix="ARK INTERNAL", name="internal",
+            git_forge=self.forge, subject_prefix="ARK INTERNAL", name="internal"
         )
         self.gitlab = gitlab_module.Gitlab(
             "https://gitlab", private_token="iaxMadvFyRCFRFH1CkW6", ssl_verify=False

--- a/patchlab/tests/test_models.py
+++ b/patchlab/tests/test_models.py
@@ -17,7 +17,7 @@ class BranchTests(BaseTestCase):
             listemail="kernel@lists.fedoraproject.org",
         )
         self.forge = models.GitForge.objects.create(
-            project=self.project, host="gitlab.example.com", forge_id=1,
+            project=self.project, host="gitlab.example.com", forge_id=1
         )
         pw_models.State(ordering=0, name="test").save()
         parse_mail(


### PR DESCRIPTION
Allow merge create and merge request hook celery tasks to retry when they hit errors.  use django db state to determine where we left off and complete work on retry

Signed-off-by: Neil Horman <nhorman@redhat.com>