### PR TITLE
Cc users to a merge request if tagged

### DIFF
--- a/patchlab/settings/base.py
+++ b/patchlab/settings/base.py
@@ -44,6 +44,10 @@ PATCHLAB_EMAIL_TO_GITLAB_COMMENT = True
 #: A list of labels that, if any are present on a merge request, are ignored.
 PATCHLAB_IGNORE_GITLAB_LABELS = ["🛑 Do Not Email"]
 
+#: A regular expression run against emails in the Cc: labels on merge requests
+#: that must match for the email to be included in the list of Ccs.
+PATCHLAB_CC_WHITELIST = r""
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/patchlab/tests/__init__.py
+++ b/patchlab/tests/__init__.py
@@ -36,6 +36,7 @@ Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH] Bring balance to the equals signs
 From: Patchwork <patchwork@patchwork.example.com>
 To: kernel@lists.fedoraproject.org
+Cc: jcline@redhat.com
 Reply-To: kernel@lists.fedoraproject.org
 Date: Mon, 04 Nov 2019 23:00:00 -0000
 Message-ID: <4@localhost.localdomain>
@@ -74,6 +75,8 @@ Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH 0/2] Update the README
 From: Patchwork <patchwork@patchwork.example.com>
 To: kernel@lists.fedoraproject.org
+Cc: another_person@example.com, jcline@redhat.com, reviewer@example.com,
+ someone@example.com
 Reply-To: kernel@lists.fedoraproject.org
 Date: Mon, 04 Nov 2019 23:00:00 -0000
 Message-ID: <1@localhost.localdomain>
@@ -82,13 +85,17 @@ X-Patchlab-Series-Version: 1
 
 From: root on gitlab.example.com
 
-Update the README to make me want to read it more.""",
+Update the README to make me want to read it more.
+
+Cc: reviewer@example.com
+""",
     """Content-Type: text/plain; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH 1/2] Bring balance to the equals signs
 From: Patchwork <patchwork@patchwork.example.com>
 To: kernel@lists.fedoraproject.org
+Cc: another_person@example.com, jcline@redhat.com, reviewer@example.com
 Reply-To: kernel@lists.fedoraproject.org
 Date: Mon, 04 Nov 2019 23:00:00 -0000
 Message-ID: <2@localhost.localdomain>
@@ -126,6 +133,7 @@ Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH 2/2] Convert the README to restructured text
 From: Patchwork <patchwork@patchwork.example.com>
 To: kernel@lists.fedoraproject.org
+Cc: jcline@redhat.com, reviewer@example.com, someone@example.com
 Reply-To: kernel@lists.fedoraproject.org
 Date: Mon, 04 Nov 2019 23:00:00 -0000
 Message-ID: <4@localhost.localdomain>

--- a/patchlab/tests/fixtures/VCR/patchlab.tests.test_gitlab2email.PrepareEmailsTests.test_ccs
+++ b/patchlab/tests/fixtures/VCR/patchlab.tests.test_gitlab2email.PrepareEmailsTests.test_ccs
@@ -30,7 +30,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 23 Oct 2019 20:23:14 GMT
+      - Wed, 23 Oct 2019 20:04:24 GMT
       Etag:
       - W/"c31a9b46130f85cf566597593da2a805"
       Referrer-Policy:
@@ -46,9 +46,9 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Request-Id:
-      - tMDcFR1OmN
+      - Y275AAHZjD1
       X-Runtime:
-      - '0.295517'
+      - '0.279525'
     status:
       code: 200
       message: OK
@@ -68,24 +68,25 @@ interactions:
       User-Agent:
       - python-requests/2.22.0
     method: GET
-    uri: https://gitlab/api/v4/projects/1/merge_requests/2
+    uri: https://gitlab/api/v4/projects/1/merge_requests/1
   response:
     body:
-      string: '{"id":2,"iid":2,"project_id":1,"title":"Update the README","description":"Update
-        the README to make me want to read it more.\n\nCc: reviewer@example.com\n","state":"opened","created_at":"2019-10-23T20:20:45.574Z","updated_at":"2019-10-23T20:20:45.574Z","merged_by":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"internal","source_branch":"multi_commit","user_notes_count":0,"upvotes":0,"downvotes":0,"assignee":null,"author":{"id":1,"name":"Administrator","username":"root","state":"active","avatar_url":"https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon","web_url":"https://gitlab/root"},"assignees":[],"source_project_id":1,"target_project_id":1,"labels":[],"work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","sha":"c321c86ee75491f4bc0b0b0e368f71eff88fa91c","merge_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":false,"reference":"!2","web_url":"https://gitlab/root/kernel/merge_requests/2","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"task_completion_status":{"count":0,"completed_count":0},"subscribed":true,"changes_count":"1","latest_build_started_at":null,"latest_build_finished_at":null,"first_deployed_to_production_at":null,"pipeline":null,"head_pipeline":{"id":3,"sha":"c321c86ee75491f4bc0b0b0e368f71eff88fa91c","ref":"multi_commit","status":"pending","created_at":"2019-10-23T20:19:52.816Z","updated_at":"2019-10-23T20:19:52.949Z","web_url":"https://gitlab/root/kernel/pipelines/3","before_sha":"0000000000000000000000000000000000000000","tag":false,"yaml_errors":null,"user":{"id":1,"name":"Administrator","username":"root","state":"active","avatar_url":"https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon","web_url":"https://gitlab/root"},"started_at":null,"finished_at":null,"committed_at":null,"duration":null,"coverage":null,"detailed_status":{"icon":"status_pending","text":"pending","label":"pending","group":"pending","tooltip":"pending","has_details":true,"details_path":"/root/kernel/pipelines/3","illustration":null,"favicon":"/assets/ci_favicons/favicon_status_pending-5bdf338420e5221ca24353b6bff1c9367189588750632e9a871b7af09ff6a2ae.png"}},"diff_refs":{"base_sha":"8fb1cd58d45e5ab5ab79d9fd5fd7b2d6e56faab2","head_sha":"c321c86ee75491f4bc0b0b0e368f71eff88fa91c","start_sha":"8fb1cd58d45e5ab5ab79d9fd5fd7b2d6e56faab2"},"merge_error":null,"user":{"can_merge":true}}'
+      string: '{"id":1,"iid":1,"project_id":1,"title":"Bring balance to the equals
+        signs","description":"This is a silly change so I can write a test.\n\nSigned-off-by:
+        Jeremy Cline \u003cjcline@redhat.com\u003e","state":"opened","created_at":"2019-10-23T19:45:43.879Z","updated_at":"2019-10-23T19:45:43.879Z","merged_by":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"internal","source_branch":"single_commit","user_notes_count":0,"upvotes":0,"downvotes":0,"assignee":null,"author":{"id":1,"name":"Administrator","username":"root","state":"active","avatar_url":"https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon","web_url":"https://gitlab/root"},"assignees":[],"source_project_id":1,"target_project_id":1,"labels":["Cc: user@example.com","Other label"],"work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","sha":"a958a0dff5e3c433eb99bc5f18cbcfad77433b0d","merge_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":false,"reference":"!1","web_url":"https://gitlab/root/kernel/merge_requests/1","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"task_completion_status":{"count":0,"completed_count":0},"subscribed":true,"changes_count":"1","latest_build_started_at":null,"latest_build_finished_at":null,"first_deployed_to_production_at":null,"pipeline":null,"head_pipeline":{"id":2,"sha":"a958a0dff5e3c433eb99bc5f18cbcfad77433b0d","ref":"single_commit","status":"pending","created_at":"2019-10-23T19:45:11.946Z","updated_at":"2019-10-23T19:45:12.349Z","web_url":"https://gitlab/root/kernel/pipelines/2","before_sha":"0000000000000000000000000000000000000000","tag":false,"yaml_errors":null,"user":{"id":1,"name":"Administrator","username":"root","state":"active","avatar_url":"https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon","web_url":"https://gitlab/root"},"started_at":null,"finished_at":null,"committed_at":null,"duration":null,"coverage":null,"detailed_status":{"icon":"status_pending","text":"pending","label":"pending","group":"pending","tooltip":"pending","has_details":true,"details_path":"/root/kernel/pipelines/2","illustration":null,"favicon":"/assets/ci_favicons/favicon_status_pending-5bdf338420e5221ca24353b6bff1c9367189588750632e9a871b7af09ff6a2ae.png"}},"diff_refs":{"base_sha":"8fb1cd58d45e5ab5ab79d9fd5fd7b2d6e56faab2","head_sha":"a958a0dff5e3c433eb99bc5f18cbcfad77433b0d","start_sha":"8fb1cd58d45e5ab5ab79d9fd5fd7b2d6e56faab2"},"merge_error":null,"user":{"can_merge":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - keep-alive
       Content-Length:
-      - '2562'
+      - '2636'
       Content-Type:
       - application/json
       Date:
-      - Wed, 23 Oct 2019 20:23:14 GMT
+      - Wed, 23 Oct 2019 20:04:24 GMT
       Etag:
-      - W/"eed6cd626d4966248dbeda388cdc5207"
+      - W/"240079aedcbea947858b160d4ddaf674"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
@@ -99,9 +100,9 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Request-Id:
-      - cpiugwvhRm2
+      - dYKTqTx0nE3
       X-Runtime:
-      - '0.064491'
+      - '0.117281'
     status:
       code: 200
       message: OK
@@ -135,7 +136,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 23 Oct 2019 20:23:14 GMT
+      - Wed, 23 Oct 2019 20:04:24 GMT
       Etag:
       - W/"5fe65894b498b2e21f9b2d6adef4d05c"
       Referrer-Policy:
@@ -151,9 +152,9 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Request-Id:
-      - xILkXWFBrTa
+      - 2kYU0ZLAPP8
       X-Runtime:
-      - '0.029473'
+      - '0.027008'
     status:
       code: 200
       message: OK
@@ -173,34 +174,30 @@ interactions:
       User-Agent:
       - python-requests/2.22.0
     method: GET
-    uri: https://gitlab/api/v4/projects/1/merge_requests/2/commits
+    uri: https://gitlab/api/v4/projects/1/merge_requests/1/commits
   response:
     body:
-      string: '[{"id":"c321c86ee75491f4bc0b0b0e368f71eff88fa91c","short_id":"c321c86e","created_at":"2019-10-23T20:17:39.000Z","parent_ids":[],"title":"Convert
-        the README to restructured text","message":"Convert the README to restructured
-        text\n\nMake the README more readable.\n\nCc: Someone <someone@example.com>\nSigned-off-by: Jeremy Cline \u003cjcline@redhat.com\u003e\n","author_name":"Jeremy
-        Cline","author_email":"jcline@redhat.com","authored_date":"2019-10-23T20:17:39.000Z","committer_name":"Jeremy
-        Cline","committer_email":"jcline@redhat.com","committed_date":"2019-10-23T20:17:39.000Z"},{"id":"5c9b066a8bc9eed0e8d7ccd392bc8f77c42532f0","short_id":"5c9b066a","created_at":"2019-10-23T20:16:57.000Z","parent_ids":[],"title":"Bring
+      string: '[{"id":"a958a0dff5e3c433eb99bc5f18cbcfad77433b0d","short_id":"a958a0df","created_at":"2019-10-23T19:29:15.000Z","parent_ids":[],"title":"Bring
         balance to the equals signs","message":"Bring balance to the equals signs\n\nThis
-        is a silly change so I can write a test.\n\nCc: Another Person <another_person@example.com>\nSigned-off-by: Jeremy Cline \u003cjcline@redhat.com\u003e\n","author_name":"Jeremy
-        Cline","author_email":"jcline@redhat.com","authored_date":"2019-10-23T20:16:57.000Z","committer_name":"Jeremy
-        Cline","committer_email":"jcline@redhat.com","committed_date":"2019-10-23T20:16:57.000Z"}]'
+        is a silly change so I can write a test.\n\nSigned-off-by: Jeremy Cline \u003cjcline@redhat.com\u003e\n","author_name":"Jeremy
+        Cline","author_email":"jcline@redhat.com","authored_date":"2019-10-23T19:27:58.000Z","committer_name":"Jeremy
+        Cline","committer_email":"jcline@redhat.com","committed_date":"2019-10-23T19:29:15.000Z"}]'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - keep-alive
       Content-Length:
-      - '1100'
+      - '552'
       Content-Type:
       - application/json
       Date:
-      - Wed, 23 Oct 2019 20:23:14 GMT
+      - Wed, 23 Oct 2019 20:04:24 GMT
       Etag:
-      - W/"a78450b1b1a2478e8394cd40e19aceff"
+      - W/"2e588c2473935869766d4a2d7c92ec40"
       Link:
-      - <https://gitlab/api/v4/projects/1/merge_requests/2/commits?id=1&merge_request_iid=2&page=1&per_page=>;
-        rel="first", <https://gitlab/api/v4/projects/1/merge_requests/2/commits?id=1&merge_request_iid=2&page=1&per_page=>;
+      - <https://gitlab/api/v4/projects/1/merge_requests/1/commits?id=1&merge_request_iid=1&page=1&per_page=>;
+        rel="first", <https://gitlab/api/v4/projects/1/merge_requests/1/commits?id=1&merge_request_iid=1&page=1&per_page=>;
         rel="last"
       Referrer-Policy:
       - strict-origin-when-cross-origin
@@ -223,11 +220,11 @@ interactions:
       X-Prev-Page:
       - ''
       X-Request-Id:
-      - AnMMJJNwDr
+      - MFwG41e0Sf4
       X-Runtime:
-      - '0.032874'
+      - '0.033745'
       X-Total:
-      - '2'
+      - '1'
       X-Total-Pages:
       - '1'
     status:
@@ -245,78 +242,11 @@ interactions:
       User-Agent:
       - python-requests/2.22.0
     method: GET
-    uri: https://gitlab/root/kernel/commit/c321c86ee75491f4bc0b0b0e368f71eff88fa91c.patch
+    uri: https://gitlab/root/kernel/commit/a958a0dff5e3c433eb99bc5f18cbcfad77433b0d.patch
   response:
     body:
-      string: "From c321c86ee75491f4bc0b0b0e368f71eff88fa91c Mon Sep 17 00:00:00 2001\n\
-        From: Jeremy Cline <jcline@redhat.com>\nDate: Wed, 23 Oct 2019 16:17:39 -0400\n\
-        Subject: [PATCH] Convert the README to restructured text\n\nMake the README\
-        \ more readable.\n\nSigned-off-by: Jeremy Cline <jcline@redhat.com>\n---\n\
-        \ README => README.rst | 0\n 1 file changed, 0 insertions(+), 0 deletions(-)\n\
-        \ rename README => README.rst (100%)\n\ndiff --git a/README b/README.rst\n\
-        similarity index 100%\nrename from README\nrename to README.rst\n-- \n2.22.0\n\
-        \n"
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Disposition:
-      - inline
-      Content-Length:
-      - '509'
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 23 Oct 2019 20:23:14 GMT
-      Referrer-Policy:
-      - strict-origin-when-cross-origin
-      - strict-origin-when-cross-origin
-      Server:
-      - nginx
-      Set-Cookie:
-      - experimentation_subject_id=ImQyYzMwZWIyLWYxZmMtNDI0MS04Yzc5LWFkNjNlOGJlOTVlNCI%3D--d10abaf2d0bb9c664af7fba62700d8d4d0316bcb;
-        path=/; expires=Sun, 23 Oct 2039 20:23:14 -0000; secure
-      Strict-Transport-Security:
-      - max-age=31536000
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - DENY
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - SMB5oEbsbW7
-      X-Runtime:
-      - '0.050463'
-      X-Ua-Compatible:
-      - IE=edge
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - experimentation_subject_id=ImQyYzMwZWIyLWYxZmMtNDI0MS04Yzc5LWFkNjNlOGJlOTVlNCI%3D--d10abaf2d0bb9c664af7fba62700d8d4d0316bcb
-      User-Agent:
-      - python-requests/2.22.0
-    method: GET
-    uri: https://gitlab/root/kernel/commit/5c9b066a8bc9eed0e8d7ccd392bc8f77c42532f0.patch
-  response:
-    body:
-      string: "From 5c9b066a8bc9eed0e8d7ccd392bc8f77c42532f0 Mon Sep 17 00:00:00 2001\n\
-        From: Jeremy Cline <jcline@redhat.com>\nDate: Wed, 23 Oct 2019 16:16:57 -0400\n\
+      string: "From a958a0dff5e3c433eb99bc5f18cbcfad77433b0d Mon Sep 17 00:00:00 2001\n\
+        From: Jeremy Cline <jcline@redhat.com>\nDate: Wed, 23 Oct 2019 15:27:58 -0400\n\
         Subject: [PATCH] Bring balance to the equals signs\n\nThis is a silly change\
         \ so I can write a test.\n\nSigned-off-by: Jeremy Cline <jcline@redhat.com>\n\
         ---\n README | 1 +\n 1 file changed, 1 insertion(+)\n\ndiff --git a/README\
@@ -335,12 +265,15 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Wed, 23 Oct 2019 20:23:15 GMT
+      - Wed, 23 Oct 2019 20:04:24 GMT
       Referrer-Policy:
       - strict-origin-when-cross-origin
       - strict-origin-when-cross-origin
       Server:
       - nginx
+      Set-Cookie:
+      - experimentation_subject_id=IjU4NWU1ZTJjLTRhYTAtNDA5ZS1iNjQ2LTZjZjczOTY1Nzg3MSI%3D--1adffe415d36e8c3a3907dc98ac24adbac019ab5;
+        path=/; expires=Sun, 23 Oct 2039 20:04:24 -0000; secure
       Strict-Transport-Security:
       - max-age=31536000
       X-Content-Type-Options:
@@ -352,9 +285,9 @@ interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 4WLmumAr89
+      - 79D0xw9sOr5
       X-Runtime:
-      - '0.044783'
+      - '0.055412'
       X-Ua-Compatible:
       - IE=edge
       X-Xss-Protection:

--- a/patchlab/tests/fixtures/VCR/patchlab.tests.test_gitlab2email.PrepareEmailsTests.test_ccs_not_whitelisted
+++ b/patchlab/tests/fixtures/VCR/patchlab.tests.test_gitlab2email.PrepareEmailsTests.test_ccs_not_whitelisted
@@ -30,7 +30,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 23 Oct 2019 20:23:14 GMT
+      - Wed, 23 Oct 2019 20:04:24 GMT
       Etag:
       - W/"c31a9b46130f85cf566597593da2a805"
       Referrer-Policy:
@@ -46,9 +46,9 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Request-Id:
-      - tMDcFR1OmN
+      - Y275AAHZjD1
       X-Runtime:
-      - '0.295517'
+      - '0.279525'
     status:
       code: 200
       message: OK
@@ -68,24 +68,25 @@ interactions:
       User-Agent:
       - python-requests/2.22.0
     method: GET
-    uri: https://gitlab/api/v4/projects/1/merge_requests/2
+    uri: https://gitlab/api/v4/projects/1/merge_requests/1
   response:
     body:
-      string: '{"id":2,"iid":2,"project_id":1,"title":"Update the README","description":"Update
-        the README to make me want to read it more.\n\nCc: reviewer@example.com\n","state":"opened","created_at":"2019-10-23T20:20:45.574Z","updated_at":"2019-10-23T20:20:45.574Z","merged_by":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"internal","source_branch":"multi_commit","user_notes_count":0,"upvotes":0,"downvotes":0,"assignee":null,"author":{"id":1,"name":"Administrator","username":"root","state":"active","avatar_url":"https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon","web_url":"https://gitlab/root"},"assignees":[],"source_project_id":1,"target_project_id":1,"labels":[],"work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","sha":"c321c86ee75491f4bc0b0b0e368f71eff88fa91c","merge_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":false,"reference":"!2","web_url":"https://gitlab/root/kernel/merge_requests/2","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"task_completion_status":{"count":0,"completed_count":0},"subscribed":true,"changes_count":"1","latest_build_started_at":null,"latest_build_finished_at":null,"first_deployed_to_production_at":null,"pipeline":null,"head_pipeline":{"id":3,"sha":"c321c86ee75491f4bc0b0b0e368f71eff88fa91c","ref":"multi_commit","status":"pending","created_at":"2019-10-23T20:19:52.816Z","updated_at":"2019-10-23T20:19:52.949Z","web_url":"https://gitlab/root/kernel/pipelines/3","before_sha":"0000000000000000000000000000000000000000","tag":false,"yaml_errors":null,"user":{"id":1,"name":"Administrator","username":"root","state":"active","avatar_url":"https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon","web_url":"https://gitlab/root"},"started_at":null,"finished_at":null,"committed_at":null,"duration":null,"coverage":null,"detailed_status":{"icon":"status_pending","text":"pending","label":"pending","group":"pending","tooltip":"pending","has_details":true,"details_path":"/root/kernel/pipelines/3","illustration":null,"favicon":"/assets/ci_favicons/favicon_status_pending-5bdf338420e5221ca24353b6bff1c9367189588750632e9a871b7af09ff6a2ae.png"}},"diff_refs":{"base_sha":"8fb1cd58d45e5ab5ab79d9fd5fd7b2d6e56faab2","head_sha":"c321c86ee75491f4bc0b0b0e368f71eff88fa91c","start_sha":"8fb1cd58d45e5ab5ab79d9fd5fd7b2d6e56faab2"},"merge_error":null,"user":{"can_merge":true}}'
+      string: '{"id":1,"iid":1,"project_id":1,"title":"Bring balance to the equals
+        signs","description":"This is a silly change so I can write a test.\n\nSigned-off-by:
+        Jeremy Cline \u003cjcline@redhat.com\u003e","state":"opened","created_at":"2019-10-23T19:45:43.879Z","updated_at":"2019-10-23T19:45:43.879Z","merged_by":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"internal","source_branch":"single_commit","user_notes_count":0,"upvotes":0,"downvotes":0,"assignee":null,"author":{"id":1,"name":"Administrator","username":"root","state":"active","avatar_url":"https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon","web_url":"https://gitlab/root"},"assignees":[],"source_project_id":1,"target_project_id":1,"labels":["Cc: user@example.com","Other label"],"work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","sha":"a958a0dff5e3c433eb99bc5f18cbcfad77433b0d","merge_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":false,"reference":"!1","web_url":"https://gitlab/root/kernel/merge_requests/1","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"task_completion_status":{"count":0,"completed_count":0},"subscribed":true,"changes_count":"1","latest_build_started_at":null,"latest_build_finished_at":null,"first_deployed_to_production_at":null,"pipeline":null,"head_pipeline":{"id":2,"sha":"a958a0dff5e3c433eb99bc5f18cbcfad77433b0d","ref":"single_commit","status":"pending","created_at":"2019-10-23T19:45:11.946Z","updated_at":"2019-10-23T19:45:12.349Z","web_url":"https://gitlab/root/kernel/pipelines/2","before_sha":"0000000000000000000000000000000000000000","tag":false,"yaml_errors":null,"user":{"id":1,"name":"Administrator","username":"root","state":"active","avatar_url":"https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon","web_url":"https://gitlab/root"},"started_at":null,"finished_at":null,"committed_at":null,"duration":null,"coverage":null,"detailed_status":{"icon":"status_pending","text":"pending","label":"pending","group":"pending","tooltip":"pending","has_details":true,"details_path":"/root/kernel/pipelines/2","illustration":null,"favicon":"/assets/ci_favicons/favicon_status_pending-5bdf338420e5221ca24353b6bff1c9367189588750632e9a871b7af09ff6a2ae.png"}},"diff_refs":{"base_sha":"8fb1cd58d45e5ab5ab79d9fd5fd7b2d6e56faab2","head_sha":"a958a0dff5e3c433eb99bc5f18cbcfad77433b0d","start_sha":"8fb1cd58d45e5ab5ab79d9fd5fd7b2d6e56faab2"},"merge_error":null,"user":{"can_merge":true}}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - keep-alive
       Content-Length:
-      - '2562'
+      - '2636'
       Content-Type:
       - application/json
       Date:
-      - Wed, 23 Oct 2019 20:23:14 GMT
+      - Wed, 23 Oct 2019 20:04:24 GMT
       Etag:
-      - W/"eed6cd626d4966248dbeda388cdc5207"
+      - W/"240079aedcbea947858b160d4ddaf674"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
@@ -99,9 +100,9 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Request-Id:
-      - cpiugwvhRm2
+      - dYKTqTx0nE3
       X-Runtime:
-      - '0.064491'
+      - '0.117281'
     status:
       code: 200
       message: OK
@@ -135,7 +136,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 23 Oct 2019 20:23:14 GMT
+      - Wed, 23 Oct 2019 20:04:24 GMT
       Etag:
       - W/"5fe65894b498b2e21f9b2d6adef4d05c"
       Referrer-Policy:
@@ -151,9 +152,9 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Request-Id:
-      - xILkXWFBrTa
+      - 2kYU0ZLAPP8
       X-Runtime:
-      - '0.029473'
+      - '0.027008'
     status:
       code: 200
       message: OK
@@ -173,34 +174,30 @@ interactions:
       User-Agent:
       - python-requests/2.22.0
     method: GET
-    uri: https://gitlab/api/v4/projects/1/merge_requests/2/commits
+    uri: https://gitlab/api/v4/projects/1/merge_requests/1/commits
   response:
     body:
-      string: '[{"id":"c321c86ee75491f4bc0b0b0e368f71eff88fa91c","short_id":"c321c86e","created_at":"2019-10-23T20:17:39.000Z","parent_ids":[],"title":"Convert
-        the README to restructured text","message":"Convert the README to restructured
-        text\n\nMake the README more readable.\n\nCc: Someone <someone@example.com>\nSigned-off-by: Jeremy Cline \u003cjcline@redhat.com\u003e\n","author_name":"Jeremy
-        Cline","author_email":"jcline@redhat.com","authored_date":"2019-10-23T20:17:39.000Z","committer_name":"Jeremy
-        Cline","committer_email":"jcline@redhat.com","committed_date":"2019-10-23T20:17:39.000Z"},{"id":"5c9b066a8bc9eed0e8d7ccd392bc8f77c42532f0","short_id":"5c9b066a","created_at":"2019-10-23T20:16:57.000Z","parent_ids":[],"title":"Bring
+      string: '[{"id":"a958a0dff5e3c433eb99bc5f18cbcfad77433b0d","short_id":"a958a0df","created_at":"2019-10-23T19:29:15.000Z","parent_ids":[],"title":"Bring
         balance to the equals signs","message":"Bring balance to the equals signs\n\nThis
-        is a silly change so I can write a test.\n\nCc: Another Person <another_person@example.com>\nSigned-off-by: Jeremy Cline \u003cjcline@redhat.com\u003e\n","author_name":"Jeremy
-        Cline","author_email":"jcline@redhat.com","authored_date":"2019-10-23T20:16:57.000Z","committer_name":"Jeremy
-        Cline","committer_email":"jcline@redhat.com","committed_date":"2019-10-23T20:16:57.000Z"}]'
+        is a silly change so I can write a test.\n\nSigned-off-by: Jeremy Cline \u003cjcline@redhat.com\u003e\n","author_name":"Jeremy
+        Cline","author_email":"jcline@redhat.com","authored_date":"2019-10-23T19:27:58.000Z","committer_name":"Jeremy
+        Cline","committer_email":"jcline@redhat.com","committed_date":"2019-10-23T19:29:15.000Z"}]'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Connection:
       - keep-alive
       Content-Length:
-      - '1100'
+      - '552'
       Content-Type:
       - application/json
       Date:
-      - Wed, 23 Oct 2019 20:23:14 GMT
+      - Wed, 23 Oct 2019 20:04:24 GMT
       Etag:
-      - W/"a78450b1b1a2478e8394cd40e19aceff"
+      - W/"2e588c2473935869766d4a2d7c92ec40"
       Link:
-      - <https://gitlab/api/v4/projects/1/merge_requests/2/commits?id=1&merge_request_iid=2&page=1&per_page=>;
-        rel="first", <https://gitlab/api/v4/projects/1/merge_requests/2/commits?id=1&merge_request_iid=2&page=1&per_page=>;
+      - <https://gitlab/api/v4/projects/1/merge_requests/1/commits?id=1&merge_request_iid=1&page=1&per_page=>;
+        rel="first", <https://gitlab/api/v4/projects/1/merge_requests/1/commits?id=1&merge_request_iid=1&page=1&per_page=>;
         rel="last"
       Referrer-Policy:
       - strict-origin-when-cross-origin
@@ -223,11 +220,11 @@ interactions:
       X-Prev-Page:
       - ''
       X-Request-Id:
-      - AnMMJJNwDr
+      - MFwG41e0Sf4
       X-Runtime:
-      - '0.032874'
+      - '0.033745'
       X-Total:
-      - '2'
+      - '1'
       X-Total-Pages:
       - '1'
     status:
@@ -245,78 +242,11 @@ interactions:
       User-Agent:
       - python-requests/2.22.0
     method: GET
-    uri: https://gitlab/root/kernel/commit/c321c86ee75491f4bc0b0b0e368f71eff88fa91c.patch
+    uri: https://gitlab/root/kernel/commit/a958a0dff5e3c433eb99bc5f18cbcfad77433b0d.patch
   response:
     body:
-      string: "From c321c86ee75491f4bc0b0b0e368f71eff88fa91c Mon Sep 17 00:00:00 2001\n\
-        From: Jeremy Cline <jcline@redhat.com>\nDate: Wed, 23 Oct 2019 16:17:39 -0400\n\
-        Subject: [PATCH] Convert the README to restructured text\n\nMake the README\
-        \ more readable.\n\nSigned-off-by: Jeremy Cline <jcline@redhat.com>\n---\n\
-        \ README => README.rst | 0\n 1 file changed, 0 insertions(+), 0 deletions(-)\n\
-        \ rename README => README.rst (100%)\n\ndiff --git a/README b/README.rst\n\
-        similarity index 100%\nrename from README\nrename to README.rst\n-- \n2.22.0\n\
-        \n"
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Disposition:
-      - inline
-      Content-Length:
-      - '509'
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 23 Oct 2019 20:23:14 GMT
-      Referrer-Policy:
-      - strict-origin-when-cross-origin
-      - strict-origin-when-cross-origin
-      Server:
-      - nginx
-      Set-Cookie:
-      - experimentation_subject_id=ImQyYzMwZWIyLWYxZmMtNDI0MS04Yzc5LWFkNjNlOGJlOTVlNCI%3D--d10abaf2d0bb9c664af7fba62700d8d4d0316bcb;
-        path=/; expires=Sun, 23 Oct 2039 20:23:14 -0000; secure
-      Strict-Transport-Security:
-      - max-age=31536000
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - DENY
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Request-Id:
-      - SMB5oEbsbW7
-      X-Runtime:
-      - '0.050463'
-      X-Ua-Compatible:
-      - IE=edge
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - experimentation_subject_id=ImQyYzMwZWIyLWYxZmMtNDI0MS04Yzc5LWFkNjNlOGJlOTVlNCI%3D--d10abaf2d0bb9c664af7fba62700d8d4d0316bcb
-      User-Agent:
-      - python-requests/2.22.0
-    method: GET
-    uri: https://gitlab/root/kernel/commit/5c9b066a8bc9eed0e8d7ccd392bc8f77c42532f0.patch
-  response:
-    body:
-      string: "From 5c9b066a8bc9eed0e8d7ccd392bc8f77c42532f0 Mon Sep 17 00:00:00 2001\n\
-        From: Jeremy Cline <jcline@redhat.com>\nDate: Wed, 23 Oct 2019 16:16:57 -0400\n\
+      string: "From a958a0dff5e3c433eb99bc5f18cbcfad77433b0d Mon Sep 17 00:00:00 2001\n\
+        From: Jeremy Cline <jcline@redhat.com>\nDate: Wed, 23 Oct 2019 15:27:58 -0400\n\
         Subject: [PATCH] Bring balance to the equals signs\n\nThis is a silly change\
         \ so I can write a test.\n\nSigned-off-by: Jeremy Cline <jcline@redhat.com>\n\
         ---\n README | 1 +\n 1 file changed, 1 insertion(+)\n\ndiff --git a/README\
@@ -335,12 +265,15 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Wed, 23 Oct 2019 20:23:15 GMT
+      - Wed, 23 Oct 2019 20:04:24 GMT
       Referrer-Policy:
       - strict-origin-when-cross-origin
       - strict-origin-when-cross-origin
       Server:
       - nginx
+      Set-Cookie:
+      - experimentation_subject_id=IjU4NWU1ZTJjLTRhYTAtNDA5ZS1iNjQ2LTZjZjczOTY1Nzg3MSI%3D--1adffe415d36e8c3a3907dc98ac24adbac019ab5;
+        path=/; expires=Sun, 23 Oct 2039 20:04:24 -0000; secure
       Strict-Transport-Security:
       - max-age=31536000
       X-Content-Type-Options:
@@ -352,9 +285,9 @@ interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 4WLmumAr89
+      - 79D0xw9sOr5
       X-Runtime:
-      - '0.044783'
+      - '0.055412'
       X-Ua-Compatible:
       - IE=edge
       X-Xss-Protection:


### PR DESCRIPTION
This is a bit of a hack, but we need to be able to indicate that certain
users should be copied on the email version of the merge request. This
allows merge requests to be tagged with tags in the format "Cc: <email>"
to Cc that email on the merge request.

Signed-off-by: Jeremy Cline <jcline@redhat.com>