### PR TITLE
Actually use the MULTILINE and IGNORECASE flags as documented

### DIFF
--- a/patchlab/models.py
+++ b/patchlab/models.py
@@ -89,7 +89,9 @@ class GitForge(models.Model):
         """
         msg = email.message_from_string(submission.headers)
         for branch in self.branches.all():
-            if re.match(branch.subject_match, msg["Subject"]):
+            if re.search(
+                branch.subject_match, msg["Subject"], flags=re.MULTILINE | re.IGNORECASE
+            ):
                 return branch.name
         else:
             raise ValueError(f"No branch matches {submission}")


### PR DESCRIPTION
The branch model documentation claims to use these flags, but does not.
Also, match only matches at the beginning of a string (basically quietly
prepending a ^) where-as search uses the regex you write.

Signed-off-by: Jeremy Cline <jcline@redhat.com>