### PR TITLE
Add configuration options to turn the email-to-gitlab bridges off

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -13,6 +13,8 @@ Django
 .. autodata:: patchlab.settings.base.PATCHLAB_GITLAB_WEBHOOK_SECRET
 .. autodata:: patchlab.settings.base.PATCHLAB_MAX_EMAILS
 .. autodata:: patchlab.settings.base.PATCHLAB_REPO_DIR
+.. autodata:: patchlab.settings.base.PATCHLAB_EMAIL_TO_GITLAB_MR
+.. autodata:: patchlab.settings.base.PATCHLAB_EMAIL_TO_GITLAB_COMMENT
 
 
 Git

--- a/patchlab/events.py
+++ b/patchlab/events.py
@@ -2,6 +2,7 @@
 import email
 import logging
 
+from django.conf import settings
 from django.db.models.signals import post_save
 from patchwork.models import Comment, Patch
 
@@ -51,7 +52,10 @@ def comment_event_handler(sender, **kwargs):
         _log.exception("Failed to dispatch task for comment %d", kwargs["instance"].id)
 
 
-post_save.connect(patch_event_handler, sender=Patch, dispatch_uid="patchlab_mr")
-post_save.connect(
-    comment_event_handler, sender=Comment, dispatch_uid="patchlab_comments"
-)
+if settings.PATCHLAB_EMAIL_TO_GITLAB_MR:
+    post_save.connect(patch_event_handler, sender=Patch, dispatch_uid="patchlab_mr")
+
+if settings.PATCHLAB_EMAIL_TO_GITLAB_COMMENT:
+    post_save.connect(
+        comment_event_handler, sender=Comment, dispatch_uid="patchlab_comments"
+    )

--- a/patchlab/settings/base.py
+++ b/patchlab/settings/base.py
@@ -33,6 +33,14 @@ PATCHLAB_MAX_EMAILS = 25
 #: <forge-host>-<forge-id>.
 PATCHLAB_REPO_DIR = "/var/lib/patchlab"
 
+#: If true, Patchlab will bridge patch series discovered by Patchwork to Gitlab
+#: merge requests.
+PATCHLAB_EMAIL_TO_GITLAB_MR = True
+
+#: If true, Patchlab will bridge emailed comments to patch series in addition
+#: to patches.
+PATCHLAB_EMAIL_TO_GITLAB_COMMENT = True
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,


### PR DESCRIPTION
It may be that users don't want to bridge comments, or don't want to
bridge emailed series and only comments in response to patches in
Gitlab. Add two settings to flip these bridges on or off (on by
default).

Signed-off-by: Jeremy Cline <jcline@redhat.com>