### PR TITLE
Use the iid for merge requests bridged from email

### DIFF
--- a/patchlab/bridge.py
+++ b/patchlab/bridge.py
@@ -157,7 +157,7 @@ def open_merge_request(
         BridgedSubmission(
             git_forge=patchwork_project.git_forge,
             submission=series.cover_letter.submission_ptr,
-            merge_request=merge_request.id,
+            merge_request=merge_request.iid,
         ).save()
 
     for patch, commit in zip(
@@ -166,7 +166,7 @@ def open_merge_request(
         bridged_submission = BridgedSubmission(
             git_forge=patchwork_project.git_forge,
             submission=patch.submission_ptr,
-            merge_request=merge_request.id,
+            merge_request=merge_request.iid,
             commit=commit.id,
         )
         bridged_submission.save()


### PR DESCRIPTION
id vs iid strikes again. iid is the project-scoped merge ID, whereas id
is the Gitlab-global id. APIs all expect the iid. This didn't get caught
in testing because there's only one project in the development
environment so the id == iid.

Signed-off-by: Jeremy Cline <jcline@redhat.com>