### PR TITLE
Allow the subject prefix to be empty in forms and default to ""

### DIFF
--- a/patchlab/migrations/0004_auto_20200428_0559.py
+++ b/patchlab/migrations/0004_auto_20200428_0559.py
@@ -1,0 +1,23 @@
+# Allow the patch prefix to be blank and default to the empty string.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("patchlab", "0003_add_submission_version"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="branch",
+            name="subject_prefix",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="The prefix to include in emails in addition to 'PATCHvN'. The default is no prefix.",
+                max_length=64,
+            ),
+        ),
+    ]

--- a/patchlab/models.py
+++ b/patchlab/models.py
@@ -119,7 +119,9 @@ class Branch(models.Model):
     subject_prefix = models.CharField(
         max_length=64,
         help_text="The prefix to include in emails in addition to "
-        "'PATCHvN'. The default will just be PATCH.",
+        "'PATCHvN'. The default is no prefix.",
+        blank=True,
+        default="",
     )
 
     subject_match = models.CharField(


### PR DESCRIPTION
The help text indicated the default prefix would be "PATCH" (a
roundabout way to say the empty string) but that doesn't match reality.
What's worse, the field was not marked blank so it's required in web
forms. Fix this and add a migration to set the default to the empty
string.

Signed-off-by: Jeremy Cline <jcline@redhat.com>