### PR TITLE
Add PATCHLAB_FROM_EMAIL setting so the forge user is clear

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -16,6 +16,10 @@ Django
 .. autodata:: patchlab.settings.base.PATCHLAB_EMAIL_TO_GITLAB_MR
 .. autodata:: patchlab.settings.base.PATCHLAB_EMAIL_TO_GITLAB_COMMENT
 .. autodata:: patchlab.settings.base.PATCHLAB_IGNORE_GITLAB_LABELS
+.. autodata:: patchlab.settings.base.PATCHLAB_CC_FILTER
+.. autodata:: patchlab.settings.base.PATCHLAB_PIPELINE_SUCCESS_REQUIRED
+.. autodata:: patchlab.settings.base.PATCHLAB_PIPELINE_MAX_WAIT
+.. autodata:: patchlab.settings.base.PATCHLAB_FROM_EMAIL
 
 
 Git

--- a/patchlab/gitlab2email.py
+++ b/patchlab/gitlab2email.py
@@ -231,6 +231,9 @@ def _prepare_emails(gitlab, git_forge, project, merge_request):
         )
         return []
 
+    from_email = settings.PATCHLAB_FROM_EMAIL.format(
+        forge_user=merge_request.author["username"]
+    )
     commits = list(reversed(list(merge_request.commits())))
     num_commits = len(commits)
     series_version, in_reply_to = _reroll(git_forge, merge_request)
@@ -270,6 +273,7 @@ def _prepare_emails(gitlab, git_forge, project, merge_request):
         cover_letter = EmailMessage(
             subject=subject,
             body=body,
+            from_email=from_email,
             to=[git_forge.project.listemail],
             cc=ccs,
             headers=headers,
@@ -322,6 +326,7 @@ def _prepare_emails(gitlab, git_forge, project, merge_request):
         email = EmailMessage(
             subject=subject,
             body=f"From: {patch_author}\n\n{patch.get_payload()}",
+            from_email=from_email,
             to=[git_forge.project.listemail],
             cc=patch_ccs,
             headers=headers,

--- a/patchlab/settings/base.py
+++ b/patchlab/settings/base.py
@@ -55,6 +55,11 @@ PATCHLAB_PIPELINE_SUCCESS_REQUIRED = False
 #: for a pipeline to complete. Defaults to 2 hours.
 PATCHLAB_PIPELINE_MAX_WAIT = 120
 
+#: The email to use for From: in bridged comments and patches. Python's
+#: `format` API will be called on the string. Currently the only key provided is
+#: `forge_author` which is set to the user's name on the Git forge.
+PATCHLAB_FROM_EMAIL = "Email Bridge on behalf of {forge_user} <bridge@example.com>"
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/patchlab/tests/__init__.py
+++ b/patchlab/tests/__init__.py
@@ -34,7 +34,7 @@ SINGLE_COMMIT_MR = """Content-Type: text/plain; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH] Bring balance to the equals signs
-From: Patchwork <patchwork@patchwork.example.com>
+From: Email Bridge on behalf of root <bridge@example.com>
 To: kernel@lists.fedoraproject.org
 Cc: jcline@redhat.com
 Reply-To: kernel@lists.fedoraproject.org
@@ -73,7 +73,7 @@ MULTI_COMMIT_MR = [
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH 0/2] Update the README
-From: Patchwork <patchwork@patchwork.example.com>
+From: Email Bridge on behalf of root <bridge@example.com>
 To: kernel@lists.fedoraproject.org
 Cc: another_person@example.com, jcline@redhat.com, reviewer@example.com,
  someone@example.com
@@ -93,7 +93,7 @@ Cc: reviewer@example.com
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH 1/2] Bring balance to the equals signs
-From: Patchwork <patchwork@patchwork.example.com>
+From: Email Bridge on behalf of root <bridge@example.com>
 To: kernel@lists.fedoraproject.org
 Cc: another_person@example.com, jcline@redhat.com, reviewer@example.com
 Reply-To: kernel@lists.fedoraproject.org
@@ -131,7 +131,7 @@ index 669ac7c32292..a0cc9c082916 100644
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH 2/2] Convert the README to restructured text
-From: Patchwork <patchwork@patchwork.example.com>
+From: Email Bridge on behalf of root <bridge@example.com>
 To: kernel@lists.fedoraproject.org
 Cc: jcline@redhat.com, reviewer@example.com, someone@example.com
 Reply-To: kernel@lists.fedoraproject.org
@@ -167,7 +167,7 @@ BIG_EMAIL = """Content-Type: text/plain; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 Subject: [TEST PATCH 0/2] Update the README
-From: Patchwork <patchwork@patchwork.example.com>
+From: Email Bridge on behalf of root <bridge@example.com>
 To: kernel@lists.fedoraproject.org
 Reply-To: kernel@lists.fedoraproject.org
 Date: Mon, 04 Nov 2019 23:00:00 -0000


### PR DESCRIPTION
Use something other than the default Django email setting for bridging
patches. Limited formatting is supported. At this time, the configured
string is formatted with the "forge_user" key set to whatever name we
can extract from the git forge. Users can still set it to something
without {forge_user} if they don't want to include the forge user's
name.

Fixes: #40
Signed-off-by: Jeremy Cline <jcline@redhat.com>