### PR TITLE
Fetch the Gitlab project with the forge_id

### DIFF
--- a/patchlab/bridge.py
+++ b/patchlab/bridge.py
@@ -53,7 +53,7 @@ def submit_gitlab_comment(gitlab: gitlab_module.Gitlab, comment: Comment) -> Non
         _log.info("Unable to find a bridged submission for %s", str(comment.submission))
         return
 
-    project = gitlab.projects.get(comment.submission.project.git_forge.project_id)
+    project = gitlab.projects.get(comment.submission.project.git_forge.forge_id)
     merge_request = project.mergerequests.get(bridged_submission.merge_request)
 
     # Turn Ack-by/Nack-by into Gitlab tags. This doesn't attempt to undo any


### PR DESCRIPTION
The emailed comment -> gitlab comment function wasn't working because it
made use of the Patchwork project id rather than the Gitlab project id.
It never got caught because all the tables use an auto-incremented
integer as the primary key so in the development environment they're all
1 and all interchangeable.

Signed-off-by: Jeremy Cline <jcline@redhat.com>