### PR TITLE
Make authors of comments submitted via email visible

### DIFF
--- a/patchlab/bridge.py
+++ b/patchlab/bridge.py
@@ -65,7 +65,11 @@ def submit_gitlab_comment(gitlab: gitlab_module.Gitlab, comment: Comment) -> Non
         merge_request.labels.append(f"{tag}: {address}")
     merge_request.save()
 
-    note = merge_request.notes.create({"body": f"```\n{comment.content}\n```"})
+    note = merge_request.notes.create(
+        {
+            "body": f"{comment.submitter} commented via email:\n```\n{comment.content}\n```"
+        }
+    )
 
     return merge_request, note
 

--- a/patchlab/gitlab2email.py
+++ b/patchlab/gitlab2email.py
@@ -188,7 +188,7 @@ def _merge_request_ccs(git_forge, merge_request):
         if cc_match:
             ccs += cc_match.groups()
 
-    ccs += [l[3:].strip() for l in merge_request.labels if l.startswith("Cc:")]
+    ccs += [line[3:].strip() for line in merge_request.labels if line.startswith("Cc:")]
     return _clean_ccs(ccs)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ basepython = python3.8
 show-source = True
 max-line-length = 100
 ignore = E203,W503
-exclude = .git,.tox,dist,*egg,patchlab/migrations/,devel/
+exclude = .git,.tox,dist,*egg,patchlab/migrations/,devel/,docs/,build/
 
 [pytest]
 DJANGO_SETTINGS_MODULE = patchlab.settings.ci


### PR DESCRIPTION
The comment content contains the email body, but unless the author signs
off their email it's not clear who sent it, and only at the end of the
comment. Include the comment submitter as a header to the comment to
make it easier to follow.

Signed-off-by: Jeremy Cline <jcline@redhat.com>